### PR TITLE
Fix kext lookup when it's inside another kext

### DIFF
--- a/OC-tool
+++ b/OC-tool
@@ -824,7 +824,7 @@ add_res_array() { # add a resource to the psuedo array (needed for POSIX)
   temp=""
   if [ -e "$BASE_DIR/extras/${res_name##*/}" ]; then #found directory (kext) or file (driver) at root level
     srce="$BASE_DIR/extras"
-  elif [ -n "$tempDest" ] && [ -e "$BASE_DIR/extras$tempDest/$res_name" ]; then #found directory (kext) or file (driver) as plugin
+  elif [ -n "$tempDest" ] && [ -e "$BASE_DIR/extras$tempDest/${res_name##*/}" ]; then #found directory (kext) or file (driver) as plugin
     srce="$BASE_DIR/extras$tempDest"
   elif [ -n "$git_url" ] || [ -n "$parent" ]; then # found repo
     srce="-$tempDest" #save path for Plugins


### PR DESCRIPTION
Fixes the validation that lookups a plugin, which is a resource inside another resource.

Issue found when trying to access VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext, which was incorrectly being marked as not found, even though VoodooRMI.kext existed and had the correct plugin inside.